### PR TITLE
Proof of Concept States

### DIFF
--- a/app/resources/js/index.js
+++ b/app/resources/js/index.js
@@ -75,7 +75,7 @@ function initCanvas() {
 	canvas.addEventListener("mousedown", setDrawPosition, false);
 	canvas.addEventListener("mouseenter", setDrawPosition, false);
 	canvas.addEventListener("mouseup",function() {
-		roomGlobal.send("test",{});
+		roomGlobal.send("test", {timestamp: Date.now()});
 	}, false);
 }
 
@@ -85,8 +85,9 @@ function initColyseusClient() {
 	client.joinOrCreate("test").then(room => {
 		console.log(room.sessionId, "joined", room.name);
 		roomGlobal = room;
-		roomGlobal.onMessage("test", (message) => {
-			console.log(message.clientSessionId + " did something.");
+		roomGlobal.onStateChange((state) => {
+			console.log(new Date(state.lastChanged).toTimeString());
+			console.log("testEventSinceServerStart: " + state.testEventSinceServerStart);
 		});
 	}).catch(e => {
 		console.log("JOIN ERROR", e);

--- a/server/RoomState.js
+++ b/server/RoomState.js
@@ -1,0 +1,15 @@
+/* eslint-env node */
+
+const schema = require("@colyseus/schema"),
+  Schema = schema.Schema;
+
+class RoomState extends Schema {
+
+}
+
+schema.defineTypes(RoomState, {
+  testEventSinceServerStart: "number",
+  lastChanged: "number", // erwartet: Rückgabewert von Date.now()
+});
+
+module.exports = RoomState;

--- a/server/TestRoom.js
+++ b/server/TestRoom.js
@@ -2,15 +2,21 @@
 /* eslint-disable no-unused-vars */
 
 const colyseus = require("colyseus");
+const RoomState = require("./RoomState.js");
 
 module.exports = class TestRoom extends colyseus.Room {
 
   onCreate(options) {
     console.log("TestRoom.onCreate():");
-    // console.log(this);
-    this.onMessage("test", (client, message) => {
-      console.log(client.sessionId + " did something.");
-      this.broadcast("test", {clientSessionId: client.sessionId});
+    this.setState(new RoomState());
+    this.onMessage("test", (client,message) => {
+      if (this.state.testEventSinceServerStart) {
+        this.state.testEventSinceServerStart++;
+      } else {
+        this.state.testEventSinceServerStart = 1;
+      }
+      this.state.lastChanged = message.timestamp;
+
     });
   }
 


### PR DESCRIPTION
Colyseus Server-Client Kommunikation jetzt mit States. Die Grundidee ist folgende:

- Client nimmt am Raum eine Änderung vor. Die Änderung über `Room.send()` (siehe [hier](https://docs.colyseus.io/client/room/#send-type-message)) an den Server kommuniziert.
- Server lauscht auf Änderungen über `Room.onMessage()` (siehe [hier](https://docs.colyseus.io/server/room/#onmessage-type-callback)). Im Callback der `onMessage()` wird die Eigenschaften von `Room.state` modifiziert.
  - Dies funktioniert direkt, z.B. `this.state.lastChanged = message.timestamp;`
- Änderungen (unklar, vielleicht auch ohne Änderung) am `RoomState` werden durch Colyseus automatisch alle 50 (?) Millisekunden an alle Clients gesendet.
- Client-side ist auf den Raum ein Listener `Room.onStateChange()` (siehe [hier](https://docs.colyseus.io/client/room/#onstatechange)) registriert. Die Callback-Funktion bekommt den `RoomState` übergeben. Mithilfe der kommunizierten Daten ließe sich die View im Client entsprechend updaten.

Diese Implementation hier dient wieder nur als Proof-of-Concept und gibt lediglich bei einem `mouseup`-Event auf das Canvas die Zeit des Events und die Zahl der Events seit Start des Servers auf der Browser-Konsole aus. Dies funktioniert Client-übergreifend, man kann die Applikation in zwei verschiedenen Fenstern aufrufen und beim malen auf das Canvas in einem Fenster erscheinen Konsolen-Ausdrücke in beiden.